### PR TITLE
Disable parallel execution in test

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -91,7 +91,6 @@ scalacOptions in (Compile, console) ~= {
 }
 
 fork in Test := true
-testForkedParallel in Test := true
 
 addCommandAlias("cpl", ";+test:compile")
 addCommandAlias(


### PR DESCRIPTION
## Changes Introduced

Parallel execution was disabled to avoid deadlocking.

## Applicable linked issues

None

## Checklist (check all that apply)

- [x] This change maintains backwards compatibility
- [ ] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [x] This pull-request is ready for review