### PR TITLE
Use retryUntil instead of filterNot

### DIFF
--- a/src/main/scala/faker/internet/PublicIpV4Address.scala
+++ b/src/main/scala/faker/internet/PublicIpV4Address.scala
@@ -7,7 +7,7 @@ final case class PublicIpV4Address private (value: String) extends AnyVal
 object PublicIpV4Address {
   private val privateFirstParts: Seq[Int] = Seq(10, 127, 169, 192, 172)
   private val publicIpV4FirstPart: Gen[Int] =
-    Gen.choose(2, 255).filterNot(privateFirstParts.contains)
+    Gen.choose(2, 255).retryUntil(!privateFirstParts.contains(_))
   implicit val publicIpV4AddressArbitrary: Arbitrary[PublicIpV4Address] =
     Arbitrary(
       for {


### PR DESCRIPTION
Attempting to avoid tests hanging

## Changes Introduced

Using retryUntil instead of filterNot in hopes to avoid hanging tests

## Applicable linked issues

None

## Checklist (check all that apply)

- [x] This change maintains backwards compatibility
- [ ] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [x] This pull-request is ready for review