### PR TITLE
Use Gen everywhere

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,12 +20,13 @@ credentials ++= (
     password
   )
 ).toSeq
+resolvers += Resolver.bintrayRepo("wolfendale", "maven")
 libraryDependencies ++= Seq(
   ScalaCheck,
   TypesafeConfig,
   PureConfig,
   ApacheCommons,
-  Generex,
+  ScalaCheckGenRegexp,
   ScalaTest % Test,
   ScalaTestPlusScalaCheck % Test
 )

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ scalacOptions ++= (ScalaVersionADT.fromString(scalaVersion.value) match {
   case `2.12` => ScalacSettings.`2.12`
   case `2.13` => ScalacSettings.`2.13`
 })
-val mimaVersion: Option[String] = Some("4.0.0")
+val mimaVersion: Option[String] = None
 mimaPreviousArtifacts :=
   mimaVersion.map("io.github.etspaceman" %% "scalacheck-faker" % _).toSet
 initialCommands in console :=

--- a/project/LibraryDependencies.scala
+++ b/project/LibraryDependencies.scala
@@ -11,5 +11,5 @@ object LibraryDependencies {
   val OrganizeImports =
     "com.github.liancheng" %% "organize-imports" % "0.3.1-RC3"
   val PureConfig = "com.github.pureconfig" %% "pureconfig" % "0.13.0"
-  val Generex = "com.github.mifmif" % "generex" % "1.0.2"
+  val ScalaCheckGenRegexp = "wolfendale" %% "scalacheck-gen-regexp" % "0.1.2"
 }

--- a/src/main/scala/faker/address/Latitude.scala
+++ b/src/main/scala/faker/address/Latitude.scala
@@ -1,14 +1,13 @@
 package faker.address
 
-import scala.util.Random
-
 import org.scalacheck.{Arbitrary, Gen}
 
 final case class Latitude private (value: String) extends AnyVal
 
 object Latitude {
-  def latitude: String = "%.8g".format((Random.nextDouble() * 180) - 90)
   implicit val latitudeArbitrary: Arbitrary[Latitude] = Arbitrary(
-    Gen.delay(latitude).map(Latitude.apply)
+    Gen
+      .choose[Double](0, 0.99)
+      .map(x => Latitude("%.8g".format((x * 180) - 90)))
   )
 }

--- a/src/main/scala/faker/address/Longitude.scala
+++ b/src/main/scala/faker/address/Longitude.scala
@@ -1,14 +1,13 @@
 package faker.address
 
-import scala.util.Random
-
 import org.scalacheck.{Arbitrary, Gen}
 
 final case class Longitude private (value: String) extends AnyVal
 
 object Longitude {
-  def longitude: String = "%.8g".format((Random.nextDouble() * 360) - 180)
   implicit val longitudeArbitrary: Arbitrary[Longitude] = Arbitrary(
-    Gen.delay(longitude).map(Longitude.apply)
+    Gen
+      .choose[Double](0, 0.99)
+      .map(x => Longitude("%.8g".format((x * 360) - 180)))
   )
 }

--- a/src/main/scala/faker/internet/Password.scala
+++ b/src/main/scala/faker/internet/Password.scala
@@ -1,7 +1,5 @@
 package faker.internet
 
-import scala.util.Random
-
 import org.scalacheck.{Arbitrary, Gen}
 
 import faker.ResourceLoader
@@ -17,16 +15,15 @@ object Password {
   ): Arbitrary[Password] =
     Arbitrary(
       for {
-        regularCharNumber <- Gen.choose(8, 20)
-        chars <-
+        charNum <- Gen.choose(8, 20)
+        specialChars <- Gen.atLeastOne(passwordSpecialCharacters)
+        pass <-
           Gen
             .listOfN(
-              regularCharNumber,
-              Gen.oneOf(LoremCharacters.loremCharacters)
+              charNum,
+              Gen.oneOf(LoremCharacters.loremCharacters ++ specialChars)
             )
             .map(_.mkString)
-        specialChars <- Gen.atLeastOne(passwordSpecialCharacters)
-        pass = Random.shuffle(chars.map(_.toString) ++ specialChars).mkString
       } yield Password(pass)
     )
 }

--- a/src/main/scala/faker/internet/Password.scala
+++ b/src/main/scala/faker/internet/Password.scala
@@ -16,12 +16,14 @@ object Password {
     Arbitrary(
       for {
         charNum <- Gen.choose(8, 20)
-        specialChars <- Gen.atLeastOne(passwordSpecialCharacters)
         pass <-
           Gen
             .listOfN(
               charNum,
-              Gen.oneOf(LoremCharacters.loremCharacters ++ specialChars)
+              Gen.frequency(
+                4 -> Gen.oneOf(LoremCharacters.loremCharacters),
+                1 -> Gen.oneOf(passwordSpecialCharacters)
+              )
             )
             .map(_.mkString)
       } yield Password(pass)

--- a/src/main/scala/faker/syntax/string.scala
+++ b/src/main/scala/faker/syntax/string.scala
@@ -1,7 +1,7 @@
 package faker.syntax
 
-import com.mifmif.common.regex.Generex
 import org.scalacheck.Gen
+import wolfendale.scalacheck.regexp.RegexpGen
 
 object string extends FakerStringSyntax
 
@@ -18,6 +18,6 @@ object FakerStringSyntax {
         else gen.map(y => y + char.toString)
       }
 
-    def regexGen: Gen[String] = Gen.delay(new Generex(str).random())
+    def regexGen: Gen[String] = RegexpGen.from(str)
   }
 }


### PR DESCRIPTION
## Changes Introduced

* Removes use of Random in favor of Gen solutions
* Replaces Generex with scalacheck-gen-regexp

This should allow for better Seed management for users of ScalaCheck, as intermingling the usage of Random directly would override that setup.

## Applicable linked issues

N/A

## Checklist (check all that apply)

- [x] This change maintains backwards compatibility
- [ ] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [x] This pull-request is ready for review