### PR TITLE
Remove Custom Resolver for scalacheck-gen-regexp

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,6 @@ credentials ++= (
     password
   )
 ).toSeq
-resolvers += Resolver.bintrayRepo("wolfendale", "maven")
 libraryDependencies ++= Seq(
   ScalaCheck,
   TypesafeConfig,

--- a/project/LibraryDependencies.scala
+++ b/project/LibraryDependencies.scala
@@ -11,6 +11,7 @@ object LibraryDependencies {
   val OrganizeImports =
     "com.github.liancheng" %% "organize-imports" % "0.5.0"
   val PureConfig = "com.github.pureconfig" %% "pureconfig" % "0.14.0"
-  val ScalaCheckGenRegexp = "io.github.wolfendale" %% "scalacheck-gen-regexp" % "0.1.3"
+  val ScalaCheckGenRegexp =
+    "io.github.wolfendale" %% "scalacheck-gen-regexp" % "0.1.3"
   val NewType = "io.estatico" %% "newtype" % "0.4.4"
 }

--- a/project/LibraryDependencies.scala
+++ b/project/LibraryDependencies.scala
@@ -11,6 +11,6 @@ object LibraryDependencies {
   val OrganizeImports =
     "com.github.liancheng" %% "organize-imports" % "0.5.0"
   val PureConfig = "com.github.pureconfig" %% "pureconfig" % "0.14.0"
-  val ScalaCheckGenRegexp = "wolfendale" %% "scalacheck-gen-regexp" % "0.1.3"
+  val ScalaCheckGenRegexp = "io.github.wolfendale" %% "scalacheck-gen-regexp" % "0.1.3"
   val NewType = "io.estatico" %% "newtype" % "0.4.4"
 }

--- a/project/LibraryDependencies.scala
+++ b/project/LibraryDependencies.scala
@@ -11,6 +11,6 @@ object LibraryDependencies {
   val OrganizeImports =
     "com.github.liancheng" %% "organize-imports" % "0.5.0"
   val PureConfig = "com.github.pureconfig" %% "pureconfig" % "0.14.0"
-  val ScalaCheckGenRegexp = "wolfendale" %% "scalacheck-gen-regexp" % "0.1.2"
+  val ScalaCheckGenRegexp = "wolfendale" %% "scalacheck-gen-regexp" % "0.1.3"
   val NewType = "io.estatico" %% "newtype" % "0.4.4"
 }


### PR DESCRIPTION
## Changes Introduced

Removing the custom resolver for scalacheck-gen-regexp per wolfendale/scalacheck-gen-regexp#8

## Applicable linked issues

N/A

## Checklist (check all that apply)

- [ ] This change maintains backwards compatibility
- [ ] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [ ] This pull-request is ready for review