### PR TITLE
Remove support for Scala 2.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        scala: [2.13, 3, 2.12]
+        scala: [2.13, 3]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
@@ -142,16 +142,6 @@ jobs:
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (2.12)
-        uses: actions/download-artifact@v4
-        with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.12
-
-      - name: Inflate target directories (2.12)
-        run: |
-          tar xf targets.tar
-          rm targets.tar
-
       - name: Import signing key
         if: env.PGP_SECRET != '' && env.PGP_PASSPHRASE == ''
         env:
@@ -209,7 +199,7 @@ jobs:
       - name: Submit Dependencies
         uses: scalacenter/sbt-dependency-submission@v2
         with:
-          modules-ignore: docs_2.13 docs_3 docs_2.12
+          modules-ignore: docs_2.13 docs_3
           configs-ignore: test scala-tool scala-doc-tool test-internal
 
   site:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -12,7 +12,6 @@ pull_request_rules:
   - body~=labels:.*early-semver-patch
   - status-success=Test (ubuntu-22.04, 2.13, temurin@17)
   - status-success=Test (ubuntu-22.04, 3, temurin@17)
-  - status-success=Test (ubuntu-22.04, 2.12, temurin@17)
   actions:
     merge:
       method: squash

--- a/build.sbt
+++ b/build.sbt
@@ -4,17 +4,15 @@ import laika.helium.Helium
 import laika.helium.config.TextLink
 import laika.helium.config.ThemeNavigationSection
 
-val Scala212 = "2.12.20"
 val Scala213 = "2.13.16"
 val Scala3 = "3.3.6"
 
-val allScalaVersions = List(Scala213, Scala3, Scala212)
+val allScalaVersions = List(Scala213, Scala3)
 
 inThisBuild(
   Seq(
     tlVersionIntroduced := Map(
       "2.13" -> "8.0.0",
-      "2.12" -> "8.0.0",
       "3" -> "8.0.0"
     ),
     tlBaseVersion := "8.0",


### PR DESCRIPTION
## Changes Introduced

This pull request removes support for Scala 2.12. Databricks has finally released a [Runtime](https://docs.databricks.com/aws/en/release-notes/runtime/16.4lts) that supports Scala 2.13, so I am comfortable dropping the support going forward.

## Applicable linked issues

## Checklist (check all that apply)

- [ ] This change maintains backwards compatibility
- [ ] I have introduced tests for all new features and changes
- [ ] I have added documentation covering all new features and changes
- [ ] This pull-request is ready for review